### PR TITLE
Update RcppArmadillo initialization

### DIFF
--- a/src/finite_moment_test.cpp
+++ b/src/finite_moment_test.cpp
@@ -407,9 +407,7 @@ arma::vec finite_moment_test(arma::vec obs,
     }
     
     // Return
-    //arma::vec return_values = {Theta, chisq1_percentile};
-    arma::vec return_values(2);
-    return_values << Theta << chisq1_percentile;
+    arma::vec return_values({Theta, chisq1_percentile});
     return(return_values);
 }
 


### PR DESCRIPTION
This one-line change updates RcppArmadillo from the now deprecated << initialization to brace initialization allowed since C++11 and long been minimal standard with R too -- and which you already had, albeit commented out. It would be great if you could merge this, and release and updated package "in the next little while" -- see the two prior emails I sent, and the transition log at RcppCore/RcppArmadillo#391